### PR TITLE
Updated readme.md files in your-turn 8 and 10 to fix problems I encountered

### DIFF
--- a/your-turn/10-testing/readme.md
+++ b/your-turn/10-testing/readme.md
@@ -15,7 +15,7 @@ To run the tests, you'll need to add a pytest run configuration. In the run conf
 
 ![](./resources/add.png)
 
-Set the target to `path` with value `./tests.py`. Now run the tests and see they are failing.
+Set the target to `path` with value `./yourtable/tests.py`. Now run the tests and see they are failing.
 
 ![](./resources/failing.png)
 

--- a/your-turn/8-python-packages/readme.md
+++ b/your-turn/8-python-packages/readme.md
@@ -36,7 +36,7 @@ For this section:
 
 ## Make it a package
 
-Use PyCharm's "create package" feature to create the package implementation itself. Name it **`calky`** as in calculator.
+Use PyCharm's "create package" feature to create the package implementation itself. Name it **`calcy`** as in calculator.
 
 ![Python package](./resources/new-package.png)
 
@@ -52,7 +52,7 @@ To make importing it easier, add this line to `__init__.py`:
 from calcy import math
 ```
 
-That means you can consume it by typing `import calky` then calling `calky.math.add(7, 11)`.
+That means you can consume it by typing `import calcy` then calling `calcy.math.add(7, 11)`.
 
 Use the Python Console in PyCharm to test this (it adds the necessary path adjustments to run the package):
 


### PR DESCRIPTION
In 8-python-packages inconsistent use of calcy and calky caused problems using the packge.  The directions in readme.md worked after changing calky to calcy every place it occurred.

In 10-testing the Working Directory: in the pytest run configuration defaulted to 10-testing so the Path
./tests.py was not found when running.  The directions in the readme.md file worked after changing ./tests.py to ./yourtable/tests.py.  Not sure if it would be better to change the Working Directory to 10-testing/yourtable instead.