### PR TITLE
README.md of 2: The Editor

### DIFF
--- a/your-turn/2-the-editor/readme.md
+++ b/your-turn/2-the-editor/readme.md
@@ -39,10 +39,10 @@ Go to the top of `program.py`. You'll see some of the imports are unused. Put yo
 
 ## Add documentation to a method
 
-The bad wizard has no documentation. Put your cursor on `hero.attack` (the attack part) on line 57 in `program.py`. Use the menu **View > Quick Documentation** and notice it's lacking.
+The bad wizard has no documentation. Put your cursor on `hero.attack` (the attack part) on line 58 in `program.py`. Use the menu **View > Quick Documentation** and notice it's lacking.
 
 Press **cmd/ctrl-b** (or **cmd/ctrl-click**) to navigate to attack. Type """[ENTER] to generate documentation.
 
-Return to line 57 in `program.py` and see your improved docs.
+Return to line 58 in `program.py` and see your improved docs.
 
 *See a mistake in these instructions? Please [submit a new issue](https://github.com/talkpython/mastering-pycharm-course/issues) or fix it and [submit a PR](https://github.com/talkpython/mastering-pycharm-course/pulls).*


### PR DESCRIPTION
Following pep8 tidying and removal of unused imports the line reference of hero.attack() was on line 58 not line 57 as noted in the *add documentation* step.
#11 
<img width="567" alt="screen shot 2018-05-16 at 9 44 53 pm" src="https://user-images.githubusercontent.com/13842157/40157919-6bbb1c0a-5956-11e8-980d-3442b9e525bf.png">
